### PR TITLE
Update Backend Image v1.0.11

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -9,7 +9,7 @@ commonLabels:
 images:
 - name: todoapp-backend
   newName: asia-northeast1-docker.pkg.dev/devops-gke-argocd/todoapp-repository/todoapp-backend
-  newTag: v1.0.10
+  newTag: v1.0.11
 - name: todoapp-frontend
   newName: asia-northeast1-docker.pkg.dev/devops-gke-argocd/todoapp-repository/todoapp-frontend
   newTag: v1.0.6


### PR DESCRIPTION
Update Backend Container Image
- New Image Tag: v1.0.11
- Build: [Click Here][1]

[1]: https://github.com/lqp2792/devops-todoapp-backend/actions/runs/2004117041