### PR TITLE
Update Frontend Image v1.0.7

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   newTag: v1.0.11
 - name: todoapp-frontend
   newName: asia-northeast1-docker.pkg.dev/devops-gke-argocd/todoapp-repository/todoapp-frontend
-  newTag: v1.0.6
+  newTag: v1.0.7


### PR DESCRIPTION
Update Frontend Container Image
- New Image Tag: v1.0.7
- Build: [Click Here][1]

[1]: https://github.com/lqp2792/devops-todoapp-frontend/actions/runs/2004118268